### PR TITLE
Add eval flag inside sequential block

### DIFF
--- a/EISANIpt/EISANIpt_EISANI_globalDefs.py
+++ b/EISANIpt/EISANIpt_EISANI_globalDefs.py
@@ -18,6 +18,7 @@ EISANIpt globalDefs
 """
 
 import math
+import ANNpt_globalDefs
 
 debugEISANIoutputs = False
 
@@ -94,6 +95,7 @@ elif(useNLPDataset):
 	NLPcharacterInputPadTokenID = 0	#must be same as bert pad token id	#assert bert_tokenizer.pad_token_id == NLPcharacterInputPadTokenID
 
 if(useSequentialSANI):
+	evalOnlyUsingTimeInvariance = False  # Assume EISANImodel was created and trained with sequentialSANItimeInvariance and useSequentialSANIactivationStrength disabled, and then loaded with sequentialSANItimeInvariance and useSequentialSANIactivationStrength enabled for inference
 	debugSequentialSANIactivationsLoops = False
 	debugSequentialSANIactivationsMemory = False
 	debugSequentialSANIactivations = False
@@ -110,6 +112,11 @@ if(useSequentialSANI):
 	#for redundancy; numberOfSynapsesPerSegment = numberOfLayers	#number of layers in network
 	sequentialSANIoverlappingSegments = True	#default: True	#orig: True	#False: contiguous segments only #disable for algorithm debug (trace activations/network gen)	#required for non-even tree structure for neuron input
 	sequentialSANItimeInvariance = True	 #default: True  #enables redundancy more immediate tokens, closer to timeIndex of the last token in the segment	
+	if(evalOnlyUsingTimeInvariance):
+		if(not ANNpt_globalDefs.stateTrainDataset and ANNpt_globalDefs.stateTestDataset):
+			sequentialSANItimeInvariance = True
+		elif(ANNpt_globalDefs.stateTrainDataset and not ANNpt_globalDefs.stateTestDataset):
+			sequentialSANItimeInvariance = False
 	if(sequentialSANItimeInvariance):
 		debugSequentialSANItimeInvarianceDisable = False	#disable time invariance for temp debug, but still print all time invariance (distance/proximity) calculations in useSequentialSANIactivationStrength
 		debugSequentialSANItimeInvarianceVerify = False
@@ -206,9 +213,7 @@ else:
 			recursiveSuperblocksNumber = 1
 	else:
 		recursiveSuperblocksNumber = 1
-	
 	generateConnectionsAfterPropagating = True	#default: True
-	
 if(useInitOrigParam):
 	useBinaryOutputConnections = True	#use binary weighted connections from hidden neurons to output neurons
 	useDynamicGeneratedHiddenConnectionsUniquenessChecks = False

--- a/EISANIpt/EISANIpt_EISANImodelSequential.py
+++ b/EISANIpt/EISANIpt_EISANImodelSequential.py
@@ -108,8 +108,10 @@ def sequentialSANIpassHiddenLayers(self, trainOrTest, batchIndex, slidingWindowI
 		if(generateConnectionsAfterPropagating):
 			dynamicallyGenerateLayerNeurons(self, trainOrTest, currentActivationTime, hiddenLayerIdx)
 		
-		layerActivationsList.append(self.layerActivationStrength)
-
+		if(evalOnlyUsingTimeInvariance):
+			layerActivationsList.append(layerActivation)
+		else:
+			layerActivationsList.append(self.layerActivationStrength)
 	#orig; layerActivationsList = self.layerActivation[1:]	#do not add input layer
 
 	return layerActivationsList


### PR DESCRIPTION
## Summary
- define `evalOnlyUsingTimeInvariance` within the `useSequentialSANI` block
- keep override of `sequentialSANItimeInvariance` immediately after declaration
- remove stray blank line after `generateConnectionsAfterPropagating`

## Testing
- `python -m py_compile EISANIpt/EISANIpt_EISANI_globalDefs.py EISANIpt/EISANIpt_EISANImodelSequential.py`


------
https://chatgpt.com/codex/tasks/task_e_686144e33df48324883c82cfd15b69eb